### PR TITLE
Pre-ship review fixes: correctness + access-control bugs

### DIFF
--- a/docs/ROLLOUT-PLAN.md
+++ b/docs/ROLLOUT-PLAN.md
@@ -1,0 +1,183 @@
+# LIQO Sales Assistant — Pilot → Adoption Rollout Plan
+
+A staged plan for LIQO to pilot the in-store recommendation assistant, prove it
+lifts the numbers that matter, and adopt it across all stores with staff buy-in.
+Written against the shipping product (React PWA + Cloudflare Workers/D1 + BUSY
+sync + gamified staff layer).
+
+**TL;DR timeline:** ~11 weeks from kickoff to network-wide adoption.
+Prep (2w) → 1-store pilot (3w) → 2-store pilot (3w) → go/no-go → phased rollout (3w).
+
+---
+
+## 1. Objectives & success metrics
+
+The product's north star is **items-per-bill** (attach rate); the secondary
+proof is that customers **buy the recommended pick**. Everything else supports
+those two.
+
+| # | KPI | Baseline (measure first) | Pilot target | Source in-product |
+|---|-----|--------------------------|--------------|-------------------|
+| 1 | **Items per bill** | current avg | **+0.3** (e.g. 1.2 → 1.5) | Command Centre north-star, Leaderboard |
+| 2 | **Bought-recommended rate** | n/a (new) | **≥ 60%** of assisted journeys | Leaderboard reco %, `/session` outcomes |
+| 3 | **Assisted conversion** (journey → bill) | walk-in close rate | **≥ walk-in +5pts** | sessions vs sales |
+| 4 | **Average ticket value** | current avg | **+8%** | `v_store_daily` revenue/bills |
+| 5 | **Ageing/dead-stock movement** | current % ≥151d | **−10%** of aged units | Command Centre ageing |
+| 6 | **Staff adoption** | 0 | **≥ 80%** of active staff run ≥5 journeys/day | sessions per user |
+| 7 | **Data freshness** | n/a | inventory sync < 90 min stale, > 98% uptime | `/catalog/health` lastSyncedAt |
+
+> Set targets *after* the Week-1 baseline read — don't guess the starting point.
+
+---
+
+## 2. Phases & go/no-go gates
+
+### Phase 0 — Readiness (Weeks 1–2, no customers yet)
+Get the plumbing and the people ready before a single customer sees it.
+
+**Tech & data**
+- Stand up Cloudflare stack via the one-shot deploy (`DEPLOY.md`): D1, API + Sync
+  workers, PWA + marketing Pages. Use the **dev** environment first (`deploy-dev.yml`).
+- Wire the **BUSY → LIQO connector** on the store's Windows/SQL box
+  (`tools/busy-connector/`): run `-Discover`, map columns, confirm the hourly
+  push lands (`/catalog/health` shows real SKUs/units per category).
+- **Inventory data-quality pass** — this makes or breaks recommendations:
+  category mapping (ac/tv/fridge/wm), price sanity (unit price, not totals),
+  star/capacity/sub-category fields populated. Fix at source or in `columnMap`.
+- Tune `config.json` price bands per category to LIQO's real ladder; set brand
+  preference/exclusions; keep LLM rationale **off** for the pilot (turn on later).
+- Seed **real staff** into `employees` (not demo accounts); set store assignments
+  and roles (admin / manager / salesperson). Disable `DEMO_LOGIN`.
+
+**Devices & environment**
+- 1–2 tablets per store (Android), PWA installed, kiosk-friendly stand, reliable
+  Wi-Fi. Test offline behaviour (PWA still runs; sessions log on reconnect).
+
+**Compliance**
+- DPDP: confirm the consent line + phone-recall opt-in copy with LIQO; anonymous
+  session logging is always on, phone-keyed writes only on consent.
+
+**Exit gate → Phase 1:** dev stack live, one store's inventory syncing cleanly,
+staff accounts working, tablet in hand, baseline metrics captured.
+
+### Phase 1 — Single-store pilot: **Zirakpur** (Weeks 3–5)
+Prove it works with real customers and real staff at one flagship pilot store.
+
+- Go live on **production** for Zirakpur only.
+- **Train** the floor: 60-min session (assisted flow, attach step, outcome
+  logging, customer recall, leaderboard). One "champion" salesperson per shift.
+- Run **assisted journeys** for a defined share of walk-ins; log every outcome.
+- Manager reviews the **Command Centre** daily; weekly check-in on the 7 KPIs.
+- Weekly config tuning based on Engine Test + real outcomes (bands, brand order).
+
+**Exit gate → Phase 2:** KPIs #1/#2/#6 trending to target, no data-integrity or
+device blockers, staff sentiment positive (Feedback screen).
+
+### Phase 2 — Two-store pilot: add **Panchkula** (Weeks 6–8)
+Validate multi-store: cross-store leaderboard competition, store-scoped offers,
+manager dashboards, and that the model generalizes to a second catalog.
+
+- Second store live; enable **inter-store Leaderboard** + a monthly **incentive
+  milestone** (items/bill, reco-rate) to drive adoption.
+- Launch 1–2 **offers with engine boost** to test the promotions loop.
+- A/B read: assisted journeys vs walk-in bills on items/bill and ticket value.
+
+**Exit gate → Rollout (go/no-go):** documented lift on items/bill AND ticket
+value across both stores, staff adoption ≥ 80%, sync uptime ≥ 98%, positive ROI
+case. **If not met**, extend pilot or remediate the failing workstream.
+
+### Phase 3 — Phased network rollout (Weeks 9–11)
+Roll to the remaining stores in waves, ~2 stores/week: **Chandigarh → Kharar →
+Pinjore → Solan** (and any others). Each store repeats a lightweight Phase-0
+checklist (inventory mapping, staff seeding, device, 45-min training).
+
+- Standing weekly network review in the Command Centre.
+- Promote a per-store champion; use the Leaderboard for healthy competition.
+
+### Phase 4 — Full adoption & optimization (ongoing)
+- Turn on **LLM "why this fits you"** rationale (Haiku) once trust is established.
+- Iterate the **questionnaire** live (admin editor + LLM suggestions) from drop-off
+  data; tune ranking blend from logged outcomes.
+- Fold in customer recall, exchange/EMI, and monthly incentive settlement into BAU.
+
+---
+
+## 3. Workstreams & owners (RACI)
+
+| Workstream | Accountable | Responsible | Key artefacts |
+|-----------|-------------|-------------|---------------|
+| Tech & deploy | Founder/CTO | Eng | `DEPLOY.md`, workflows, `/catalog/health` |
+| Inventory data & BUSY sync | Store IT / BUSY vendor | Eng | `tools/busy-connector/`, `docs/DATA-SOURCES.md` |
+| Engine config & tuning | Founder | Admin (Config Editor) | `config.json`, Engine Test console |
+| Ops & training | Regional/Store Manager | Store champions | training deck, kiosk setup |
+| Change mgmt & incentives | Founder + Managers | HR/Managers | Milestones, Leaderboard, Incentives |
+| Compliance (DPDP) | Founder | — | consent copy, erase-by-phone flow |
+| Measurement | Founder | Managers | Command Centre, weekly KPI sheet |
+
+---
+
+## 4. Adoption levers (why staff will actually use it)
+
+Adoption is the #1 risk in retail tools. The product already ships the levers —
+use them deliberately:
+
+- **Gamified Leaderboard** (weekly/monthly, within- and cross-store) — visible
+  points that trace to real bills; healthy rep-vs-rep and store-vs-store competition.
+- **Incentives ledger** tied to **milestones** (items/bill ≥1.5, reco-rate ≥70%,
+  bills, revenue) with a rupee value (50 pts = ₹1) — money, not just badges.
+- **Manager visibility** — Command Centre store comparison surfaces laggards early.
+- **Make it faster than not using it** — recall by phone, one-tap attach, WhatsApp
+  summary. Frame it as *"close bigger bills faster,"* not *"more admin."*
+- **Champions per shift** — peer proof beats top-down mandates.
+
+---
+
+## 5. Measurement plan
+
+- **Baseline first (Week 1):** current items/bill, avg ticket, close rate, aged-stock %.
+- **During pilot:** assisted-journey cohort vs walk-in control on the same store/period.
+- **Instruments:** Command Centre (north-star, store comparison, ageing, trading,
+  demand conversion), Leaderboard (per-rep items/bill + reco%), `/session` outcomes,
+  `/catalog/health` (data freshness), Feedback (staff sentiment).
+- **Cadence:** daily glance (manager), weekly KPI review (founder + managers),
+  end-of-phase go/no-go written decision.
+
+---
+
+## 6. Risks & mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|-----------|
+| Poor inventory data (bad category/price/specs) | Bad recommendations, lost trust | Week-0 data-quality gate; fix at BUSY source; `/catalog/health` monitoring |
+| Sync gaps / stale stock | Recommends out-of-stock items | Hourly cron + freshness alert; "confirm stock at billing" already on cards |
+| Low staff adoption | No lift | Champions, leaderboard, incentive money, manager dashboards, fast UX |
+| Connectivity drops on floor | Journeys stall | PWA offline mode (bundled engine); sessions sync on reconnect |
+| Privacy/DPDP concerns | Compliance risk | Consent-gated phone capture, anonymous-by-default logging, erase-by-phone |
+| Device loss/misuse | Cost, data | Kiosk lockdown, per-store device count, staff login (no shared creds) |
+| Over-reliance on "stretch"/margin push | Customer distrust | Ranking is hidden; honest pros/cons; monitor reco-adoption & returns |
+
+---
+
+## 7. Rollback / contingency
+
+- Per-store **kill switch:** point that store's staff back to normal selling; the
+  app is additive, not a system-of-record, so nothing else breaks.
+- **Data issue:** an empty/failed feed no longer wipes the catalog (atomic
+  replace); Sync Worker retries hourly; manual `/sync` for ad-hoc refresh.
+- **Config regression:** engine config is versioned and editable live (no redeploy);
+  revert to the last-known-good config from the admin editor.
+
+---
+
+## 8. One-page checklist per store (rollout wave)
+
+- [ ] BUSY connector mapped + hourly push verified (`/catalog/health`)
+- [ ] Inventory data-quality pass (category, price, specs) signed off
+- [ ] Price bands / brand order tuned for the store's catalog
+- [ ] Real staff seeded with roles + store; demo login disabled
+- [ ] Tablet(s) provisioned, PWA installed, Wi-Fi + kiosk stand tested
+- [ ] DPDP consent copy confirmed
+- [ ] 45–60 min staff training + champion named
+- [ ] Baseline KPIs captured
+- [ ] First-week daily Command Centre review scheduled
+- [ ] Go/no-go criteria agreed in writing

--- a/src/engine/mapper.ts
+++ b/src/engine/mapper.ts
@@ -190,11 +190,13 @@ function round4(n: number): number {
 }
 
 function deriveCategory(row: RawInventoryRow): Category | null {
-  const raw = (row.category ?? "").toLowerCase();
+  const raw = (row.category ?? "").trim().toLowerCase();
   if (["ac", "tv", "fridge", "wm"].includes(raw)) return raw as Category;
   const label = (row.category_label ?? row.categoryLabel ?? row.name ?? "").toLowerCase();
-  if (label.includes("air condition") || label.includes("ac")) return "ac";
-  if (label.includes("tv") || label.includes("television")) return "tv";
+  // Match "ac"/"tv" only as whole words — a bare substring test misfires on
+  // ordinary product names ("black" contains "ac", "outlet" contains "tv"…).
+  if (/air.?condition/.test(label) || /\bac\b/.test(label)) return "ac";
+  if (/\btv\b/.test(label) || label.includes("television")) return "tv";
   if (label.includes("refriger") || label.includes("fridge")) return "fridge";
   if (label.includes("wash")) return "wm";
   return null;

--- a/src/engine/points.test.ts
+++ b/src/engine/points.test.ts
@@ -49,6 +49,19 @@ describe("computeLeaderboard", () => {
   it("sorts by monthly points descending", () => {
     expect(rows[0].userId).toBe("u1");
   });
+
+  it("counts reco rate for the app's underscore outcome vocabulary", () => {
+    // The PWA emits `bought_recommended` (underscore); the leaderboard must
+    // normalise it the same way isBill/pointsForSession do, else recoRate is
+    // stuck at 0 on every live deployment.
+    const appSessions: SessionRecord[] = [
+      { userId: "u9", storeId: "s2", outcome: "bought_recommended", itemsPerBill: 1, total: 40000, ts: daysAgo(1) },
+      { userId: "u9", storeId: "s2", outcome: "bought_different", itemsPerBill: 1, total: 30000, ts: daysAgo(2) },
+    ];
+    const [u9] = computeLeaderboard(appSessions, { u9: { name: "C", storeId: "s2" } }, NOW);
+    expect(u9.bills).toBe(2);
+    expect(u9.recoRate).toBeCloseTo(0.5, 5);
+  });
 });
 
 describe("pointsToInr (50 pts = ₹1)", () => {

--- a/src/engine/points.ts
+++ b/src/engine/points.ts
@@ -128,7 +128,9 @@ export function computeLeaderboard(
     if (ageDays <= 7) a.week += pts;
     a.bills += 1;
     a.ipbSum += s.itemsPerBill ?? 1;
-    if (s.outcome === "bought-recommended") a.reco += 1;
+    // Normalise so the app's `bought_recommended` (underscore) and the
+    // engine/tests' `bought-recommended` (hyphen) both count toward reco rate.
+    if (normOutcome(s.outcome) === "bought-recommended") a.reco += 1;
     a.days.add(dayKey(new Date(ts).toISOString()));
   }
 

--- a/src/shared/d1.ts
+++ b/src/shared/d1.ts
@@ -141,19 +141,25 @@ const PLACEHOLDERS = INVENTORY_COLUMNS.map(() => "?").join(", ");
 const UPSERT_SQL = `INSERT OR REPLACE INTO inventory (${INVENTORY_COLUMNS.join(", ")}) VALUES (${PLACEHOLDERS})`;
 
 /**
- * Atomically replace the inventory snapshot: clear, then batch-insert.
- * Done in chunks to stay within D1 statement limits.
+ * Atomically replace the inventory snapshot.
+ *
+ * The DELETE and every insert run inside ONE db.batch(), which D1 executes as a
+ * single transaction (all-or-nothing). If any statement fails the whole thing
+ * rolls back, so the catalog can never be left empty or half-populated — unlike
+ * a bare `DELETE` followed by separate insert batches.
+ *
+ * An empty feed is treated as "nothing to apply": we do NOT wipe the live
+ * snapshot, so a transient upstream failure that yields zero rows can't take the
+ * whole catalog offline.
  */
-export async function replaceInventory(db: D1Like, items: InventoryItem[], chunk = 50): Promise<number> {
-  await db.exec("DELETE FROM inventory");
-  let written = 0;
-  for (let i = 0; i < items.length; i += chunk) {
-    const slice = items.slice(i, i + chunk);
-    const stmts = slice.map((it) => db.prepare(UPSERT_SQL).bind(...itemToBindings(it)));
-    await db.batch(stmts);
-    written += slice.length;
-  }
-  return written;
+export async function replaceInventory(db: D1Like, items: InventoryItem[]): Promise<number> {
+  if (items.length === 0) return 0;
+  const stmts: D1PreparedLike[] = [
+    db.prepare("DELETE FROM inventory"),
+    ...items.map((it) => db.prepare(UPSERT_SQL).bind(...itemToBindings(it))),
+  ];
+  await db.batch(stmts);
+  return items.length;
 }
 
 export async function loadInventory(db: D1Like, where?: { storeId?: string; category?: string }): Promise<InventoryItem[]> {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -97,10 +97,16 @@ function readOverride<T>(key: string): T | null {
   }
 }
 
-export async function getConfig(): Promise<EngineConfig> {
+/**
+ * Load the engine config. The customer-facing flow calls this with no token and
+ * receives the public subset (price bands / attach / emi). Admin tools pass the
+ * bearer token to receive the FULL editable config (commercial params included).
+ */
+export async function getConfig(token?: string | null): Promise<EngineConfig> {
   const ov = readOverride<EngineConfig>(CFG_OVERRIDE);
   if (ov) return ov;
-  return getJSON<EngineConfig>(IS_REMOTE ? `${API_BASE}/config` : `${BASE}config.json`);
+  if (IS_REMOTE) return getJSONAuth<EngineConfig>(`${API_BASE}/config`, token);
+  return getJSON<EngineConfig>(`${BASE}config.json`);
 }
 
 export async function getQuestionnaire(): Promise<Questionnaire> {
@@ -319,7 +325,8 @@ export async function apiLogin(email: string, password: string): Promise<{ token
   }
   const { demoPassword, users } = await getDemoUsers();
   const u = users.find((x) => x.email.toLowerCase() === email.trim().toLowerCase());
-  if (!u || (password && password !== demoPassword)) throw new Error("Invalid email or password");
+  // Require the demo password outright — an empty password must never sign in.
+  if (!u || password !== demoPassword) throw new Error("Invalid email or password");
   const user: AuthUser = { id: u.id, email: u.email, name: u.name, role: u.role, storeId: u.storeId, title: u.title };
   return { token: `demo:${u.id}`, user };
 }

--- a/web/src/lib/format.ts
+++ b/web/src/lib/format.ts
@@ -9,9 +9,9 @@ export function rupees(n: number): string {
  * Localised "Up to ₹X" / "₹X–Y" / "Above ₹X" label for a price-band tuple.
  * The engine bands are [min, max); we render the human range from the tuple.
  */
-export function bandRangeLabel(tuple: [number, number]): string {
+export function bandRangeLabel(tuple: [number, number], lang: "en" | "hi" = "en"): string {
   const [min, max] = tuple;
-  if (min <= 0) return `Up to ${rupees(max)}`;
-  if (max >= 1_000_000) return `Above ${rupees(min)}`;
+  if (min <= 0) return lang === "hi" ? `${rupees(max)} तक` : `Up to ${rupees(max)}`;
+  if (max >= 1_000_000) return lang === "hi" ? `${rupees(min)} से ऊपर` : `Above ${rupees(min)}`;
   return `${rupees(min)}–${rupees(max)}`;
 }

--- a/web/src/screens/Budget.tsx
+++ b/web/src/screens/Budget.tsx
@@ -62,7 +62,7 @@ export default function Budget({
                 onClick={() => onPickBand(band)}
               >
                 <div className="b-tier">{t(UI[tierLabel], lang)}</div>
-                <div className="b-amt">{bandRangeLabel(bands[band])}</div>
+                <div className="b-amt">{bandRangeLabel(bands[band], lang)}</div>
               </button>
             );
           })}

--- a/web/src/screens/ConfigEditor.tsx
+++ b/web/src/screens/ConfigEditor.tsx
@@ -20,7 +20,7 @@ export default function ConfigEditor({ lang, token, onChanged }: { lang: Lang; t
   const [err, setErr] = useState<string | null>(null);
   const [edited, setEdited] = useState(false);
 
-  useEffect(() => { getConfig().then((c) => { setDraft(clone(c)); setEdited(hasConfigOverride()); }); }, []);
+  useEffect(() => { getConfig(token).then((c) => { setDraft(clone(c)); setEdited(hasConfigOverride()); }); }, [token]);
 
   if (!draft) return <div className="loading">…</div>;
   const patch = (fn: (d: EngineConfig) => void) => { setDraft((d) => { const n = clone(d!); fn(n); return n; }); setStatus("idle"); };
@@ -36,7 +36,7 @@ export default function ConfigEditor({ lang, token, onChanged }: { lang: Lang; t
   }
   async function reset() {
     setStatus("saving");
-    try { await resetConfigLive(token); const c = await getConfig(); setDraft(clone(c)); setEdited(false); setStatus("idle"); onChanged?.(); }
+    try { await resetConfigLive(token); const c = await getConfig(token); setDraft(clone(c)); setEdited(false); setStatus("idle"); onChanged?.(); }
     catch (e) { setErr((e as Error).message); setStatus("error"); }
   }
 

--- a/worker-api/src/dao.ts
+++ b/worker-api/src/dao.ts
@@ -1109,10 +1109,15 @@ export async function addDemandRequest(db: D1Like, rec: DemandRequestInput): Pro
 // ===========================================================================
 // analytics  (read-only views)
 // ===========================================================================
-/** v_store_daily, optionally one store, last N days (by day string). */
+/**
+ * v_store_daily rows, optionally one store, on/after `sinceDay` (a 'YYYY-MM-DD'
+ * cutoff). The view is one row per store per day, so the window MUST be filtered
+ * by the day string — a bare LIMIT would cap total rows and, with several
+ * stores, silently collapse "last N days" down to a single day.
+ */
 export async function storeDaily(
   db: D1Like,
-  where: { storeId?: string; days?: number } = {},
+  where: { storeId?: string; sinceDay?: string } = {},
 ): Promise<StoreDailyRow[]> {
   const clauses: string[] = [];
   const binds: unknown[] = [];
@@ -1120,14 +1125,14 @@ export async function storeDaily(
     clauses.push("store_id = ?");
     binds.push(where.storeId);
   }
-  let sql =
+  if (where.sinceDay) {
+    clauses.push("day >= ?");
+    binds.push(where.sinceDay);
+  }
+  const sql =
     "SELECT * FROM v_store_daily" +
     (clauses.length ? " WHERE " + clauses.join(" AND ") : "") +
     " ORDER BY day DESC, store_id";
-  if (where.days != null) {
-    sql += " LIMIT ?";
-    binds.push(where.days);
-  }
   const { results } = await db.prepare(sql).bind(...binds).all<StoreDailyRow>();
   return results;
 }

--- a/worker-api/src/index.ts
+++ b/worker-api/src/index.ts
@@ -43,11 +43,22 @@ interface DemoUser {
 const USERS = usersFile as { demoPassword: string; users: DemoUser[] };
 const LEADERBOARD = leaderboardFile as { rows: LeaderboardRow[] };
 
-/** Salesperson roster (id -> name + home store) for leaderboard rendering. */
-function salesRoster(): Record<string, RosterEntry> {
+/** Salesperson roster (id -> name + home store) for leaderboard rendering.
+ *  Sourced from the live D1 `employees` table so real (imported) staff render
+ *  with their names, not raw ids. Falls back to the bundled demo users only
+ *  when the table is empty (offline / first bring-up). */
+async function salesRoster(db: D1Like): Promise<Record<string, RosterEntry>> {
   const roster: Record<string, RosterEntry> = {};
-  for (const u of USERS.users) {
-    if (u.role === "salesperson" && u.storeId) roster[u.id] = { name: u.name, storeId: u.storeId };
+  try {
+    const emps = await dao.listEmployees(db, { role: "salesperson" });
+    for (const e of emps) if (e.store_id) roster[e.employee_id] = { name: e.name, storeId: e.store_id };
+  } catch {
+    /* fall through to the bundled roster */
+  }
+  if (Object.keys(roster).length === 0) {
+    for (const u of USERS.users) {
+      if (u.role === "salesperson" && u.storeId) roster[u.id] = { name: u.name, storeId: u.storeId };
+    }
   }
   return roster;
 }
@@ -94,7 +105,7 @@ async function route(req: Request, env: Env, url: URL, pathname: string, method:
       if (pathname === "/stores" && method === "GET") return handleStores(env);
       if (pathname === "/catalog/health" && method === "GET") return handleCatalogHealth(env);
       if (pathname === "/session" && method === "POST") return handleSession(req, env);
-      if (pathname === "/config" && method === "GET") return handleGetConfig(env);
+      if (pathname === "/config" && method === "GET") return handleGetConfig(req, env);
       if (pathname === "/config" && method === "PUT") return handlePutConfig(req, env);
       if (pathname === "/questionnaire" && method === "GET") return handleGetQuestionnaire(env);
       if (pathname === "/questionnaire" && method === "PUT") return handlePutQuestionnaire(req, env);
@@ -380,7 +391,7 @@ async function handleLeaderboard(env: Env, url: URL): Promise<Response> {
     .catch(() => ({ results: [] as SessionRecord[] }));
   const hasRealBills = results.some((r) => isBill(r.outcome));
   let rows = hasRealBills
-    ? computeLeaderboard(results, salesRoster(), new Date().toISOString())
+    ? computeLeaderboard(results, await salesRoster(env.DB), new Date().toISOString())
     : LEADERBOARD.rows;
   if (storeId) rows = rows.filter((r) => r.storeId === storeId);
   return json(env, { rows });
@@ -511,12 +522,27 @@ async function handleSession(req: Request, env: Env): Promise<Response> {
 // ---------------------------------------------------------------------------
 // GET/PUT /config  (admin token)
 // ---------------------------------------------------------------------------
-async function handleGetConfig(env: Env): Promise<Response> {
-  // Public read — the app needs price bands / attach live.
-  // TODO(prod): split a public app-config (bands, attach, emi) from the full
-  // commercial config (rankingBlend, brandPreference, marginModel).
+async function handleGetConfig(req: Request, env: Env): Promise<Response> {
   const cfg = await loadConfig(env.DB);
-  return json(env, cfg);
+  // Signed-in staff (e.g. the admin Config Editor) get the FULL doc so they can
+  // read + round-trip every parameter. The unauthenticated customer-facing flow
+  // only needs price bands / attach / emi, so commercial params (rankingBlend,
+  // brandPreference, brandExclusions, marginModel, fit, transform, ageingModel)
+  // are NOT exposed publicly.
+  if (await checkRole(req, env, STAFF_ROLES)) return json(env, cfg);
+  return json(env, publicConfig(cfg));
+}
+
+/** The safe-to-expose subset of the engine config for the public app flow. */
+function publicConfig(cfg: EngineConfig): Partial<EngineConfig> {
+  return {
+    version: cfg.version,
+    updatedAt: cfg.updatedAt,
+    priceBands: cfg.priceBands,
+    attach: cfg.attach,
+    emi: cfg.emi,
+    stretchThreshold: cfg.stretchThreshold,
+  };
 }
 
 async function handlePutConfig(req: Request, env: Env): Promise<Response> {
@@ -894,15 +920,22 @@ async function handleDecideLeave(req: Request, env: Env, idStr: string): Promise
 }
 
 // --- milestones + incentives ---
+// Readable by any signed-in staff member: milestones are the shared targets and
+// every salesperson needs to see their own incentive ledger (the gamification
+// loop). Salespeople are scoped to their OWN rows; managers/admins may filter.
 async function handleListMilestones(req: Request, env: Env): Promise<Response> {
-  if (!(await checkAdmin(req, env))) return unauthorized(env);
+  if (!(await checkRole(req, env, STAFF_ROLES))) return unauthorized(env);
   return json(env, { milestones: await dao.listMilestones(env.DB) });
 }
 
 async function handleListIncentives(req: Request, env: Env, url: URL): Promise<Response> {
-  if (!(await checkAdmin(req, env))) return unauthorized(env);
+  if (!(await checkRole(req, env, STAFF_ROLES))) return unauthorized(env);
+  const payload = await tokenPayload(req, env);
+  let employeeId = url.searchParams.get("employeeId") ?? undefined;
+  // A salesperson may only ever read their own ledger, whatever they ask for.
+  if (payload?.role === "salesperson") employeeId = payload.sub ?? "__none__";
   const incentives = await dao.listIncentives(env.DB, {
-    employeeId: url.searchParams.get("employeeId") ?? undefined,
+    employeeId,
     period: url.searchParams.get("period") ?? undefined,
   });
   return json(env, { incentives });
@@ -957,6 +990,7 @@ async function handleListDemand(req: Request, env: Env, url: URL): Promise<Respo
 }
 
 async function handleAddDemand(req: Request, env: Env): Promise<Response> {
+  if (!(await checkRole(req, env, STAFF_ROLES))) return unauthorized(env);
   const b = await readBody(req);
   const id = await dao.addDemandRequest(env.DB, {
     storeId: str(b.store_id ?? b.storeId),
@@ -1016,9 +1050,13 @@ async function handleEngineTest(req: Request, env: Env): Promise<Response> {
 // --- analytics (views) ---
 async function handleAnalyticsStoreDaily(req: Request, env: Env, url: URL): Promise<Response> {
   if (!(await checkRole(req, env, MANAGER))) return unauthorized(env);
+  // Interpret ?days=N as a real date window (last N calendar days), not a row
+  // cap — v_store_daily is one row per store per day.
+  const days = num(url.searchParams.get("days")) ?? 30;
+  const sinceDay = new Date(Date.now() - days * 86400000).toISOString().slice(0, 10);
   const rows = await dao.storeDaily(env.DB, {
     storeId: url.searchParams.get("storeId") ?? undefined,
-    days: num(url.searchParams.get("days")) ?? undefined,
+    sinceDay,
   });
   return json(env, { rows });
 }
@@ -1075,6 +1113,16 @@ async function checkRole(req: Request, env: Env, roles: string[]): Promise<boole
   const payload = await verifyToken(env, token);
   const role = payload?.role;
   return !!role && (role === "admin" || roles.includes(role));
+}
+
+/** The verified caller identity, or null. The ADMIN_TOKEN secret maps to a
+ *  synthetic admin (no `sub`), matching how checkAdmin/checkRole treat it. */
+async function tokenPayload(req: Request, env: Env): Promise<{ role?: string; sub?: string } | null> {
+  const auth = req.headers.get("authorization") ?? "";
+  const token = auth.replace(/^Bearer\s+/i, "").trim() || req.headers.get("x-admin-token") || "";
+  if (!token) return null;
+  if (env.ADMIN_TOKEN && token === env.ADMIN_TOKEN) return { role: "admin" };
+  return verifyToken(env, token);
 }
 
 async function verifyToken(env: Env, token: string): Promise<{ role?: string; sub?: string } | null> {


### PR DESCRIPTION
Fixes the real bugs found in the pre-ship review. Most only bite on a **live (remote) deployment** — the offline/demo paths bypass the server, so CI and the GitHub Pages demo look green while the pilot breaks.

## Critical / High
- **recoRate always 0% on live.** `computeLeaderboard` counted "bought-recommended" with a raw compare, but the PWA emits `bought_recommended` (underscore). Now normalizes like `isBill`/`pointsForSession` do. Added a regression test using the underscore vocabulary the app actually sends. (`src/engine/points.ts`)
- **Incentives & Milestones dead for staff.** `/milestones` and `/incentives` were admin-only, but the nav shows them to managers and salespeople → silent empty screens. Now open to signed-in staff; salespeople are scoped to their own ledger. (`worker-api/src/index.ts`)
- **Leaderboard showed employee IDs, not names.** The roster was built from the bundled `data/users.json` (demo accounts). Now sourced from the D1 `employees` table, falling back to the bundled users only when empty. (`worker-api/src/index.ts`)

## Medium
- **`GET /config` leaked the commercial ranking logic.** Was fully public. Now returns the full config only to signed-in staff; the unauthenticated customer flow gets a price-band/attach/emi subset. The admin Config Editor threads its token so it still round-trips the full doc. (`worker-api/src/index.ts`, `web/src/lib/api.ts`, `web/src/screens/ConfigEditor.tsx`)
- **`POST /demand` accepted unauthenticated writes.** Now requires a staff role. (`worker-api/src/index.ts`)
- **`replaceInventory` could wipe the catalog.** `DELETE` + separate insert batches weren't atomic. Now one atomic `db.batch`, and an empty feed never wipes the live snapshot. (`src/shared/d1.ts`)
- **Command Centre "last 7 days" showed ~1 day.** `?days=N` was applied as a row `LIMIT` on a per-store-per-day view. Now a real date-window filter. (`worker-api/src/dao.ts`, `worker-api/src/index.ts`)

## Low
- Offline demo login no longer accepts an empty password. (`web/src/lib/api.ts`)
- `deriveCategory` matches `ac`/`tv` as whole words, not substrings ("black" no longer classifies as AC). (`src/engine/mapper.ts`)
- Localized the budget band-range label (Hindi). (`web/src/lib/format.ts`, `web/src/screens/Budget.tsx`)

## Verification
- `npm test` → **61 unit tests pass** (was 60; +1 reco-vocabulary regression test)
- `worker-api` / `worker-sync` / `web` / engine all typecheck
- PWA production build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FwtimstjM15DPvYtctuWcK

---
_Generated by [Claude Code](https://claude.ai/code/session_01FwtimstjM15DPvYtctuWcK)_